### PR TITLE
Feat/add class to code blocks

### DIFF
--- a/R/hooks-md.R
+++ b/R/hooks-md.R
@@ -134,14 +134,21 @@ render_markdown = function(strict = FALSE, fence_char = '`') {
   hook.o = function(class) {
     force(class)
     function(x, options) {
-      hook.t(x, options, options[[paste0('attr.', class)]], options[[paste0('class.', class)]])
+      hook.t(
+        x, options, options[[paste0('attr.', class)]],
+        c(options[[paste0('class.', class)]], paste0('chunk-', class))
+      )
     }
   }
   hook.r = function(x, options) {
     language = tolower(options$engine)
     if (language == 'node') language = 'javascript'
     if (!options$highlight) language = 'text'
-    attrs = block_attr(options$attr.source, options$class.source, language)
+    attrs = block_attr(
+      options$attr.source,
+      c(options$class.source, "chunk-source"),
+      language
+    )
     paste0('\n\n', fence, attrs, '\n', x, fence, '\n\n')
   }
   hooks = list()

--- a/tests/testit/test-hooks.R
+++ b/tests/testit/test-hooks.R
@@ -36,44 +36,44 @@ hook_src = knit_hooks$get("source")
 options_ = list(engine = "r", prompt = FALSE, highlight = TRUE)
 
 assert(
-  'Attributes for souce can be specified class.source and attr.source',
+  'Attributes for soruce can be specified by class.source and attr.source',
   identical(
     hook_src("1", c(options_, class.source = "a b")),
-    "\n\n```{.r .a .b}\n1\n```\n\n"
+    "\n\n```{.r .a .b .chunk-source}\n1\n```\n\n"
   ),
   identical(
     hook_src("1", c(options_, attr.source = ".a .b")),
-    "\n\n```{.r .a .b}\n1\n```\n\n"
+    "\n\n```{.r .chunk-source .a .b}\n1\n```\n\n"
   ),
   identical(
     hook_src("1", c(options_, class.source = "a", attr.source = "b='1'")),
-    "\n\n```{.r .a b='1'}\n1\n```\n\n"
+    "\n\n```{.r .a .chunk-source b='1'}\n1\n```\n\n"
   ),
   identical(
     hook_src("1", c(options_, attr.source = ".a b='1'")),
-    "\n\n```{.r .a b='1'}\n1\n```\n\n"
+    "\n\n```{.r .chunk-source .a b='1'}\n1\n```\n\n"
   )
 )
 
 hook_out = knit_hooks$get("output")
 
 assert(
-  'Attributes for souce can be specified class.source and attr.source',
+  'Attributes for ouptput can be specified by class.output and attr.output',
   identical(
     hook_out("1\n", c(options_, class.output = "a b")),
-    "\n\n```{.a .b}\n1\n```\n\n"
+    "\n\n```{.a .b .chunk-output}\n1\n```\n\n"
   ),
   identical(
     hook_out("1\n", c(options_, attr.output = ".a .b")),
-    "\n\n```{.a .b}\n1\n```\n\n"
+    "\n\n```{.chunk-output .a .b}\n1\n```\n\n"
   ),
   identical(
     hook_out("1\n", c(options_, class.output = "a", attr.output = "b='1'")),
-    "\n\n```{.a b='1'}\n1\n```\n\n"
+    "\n\n```{.a .chunk-output b='1'}\n1\n```\n\n"
   ),
   identical(
     hook_out("1\n", c(options_, attr.output = ".a b='1'")),
-    "\n\n```{.a b='1'}\n1\n```\n\n"
+    "\n\n```{.chunk-output .a b='1'}\n1\n```\n\n"
   )
 )
 


### PR DESCRIPTION
Currently it is not possible to distinguish if code blocks generated by chunks are `source`, `output`, `message`, `warning`, or `error`.
This PR enables it by giving following class attributes to code blocks, respectively: `chunk-source`, `chunk-output`, `chunk-message`, `chunk-warning`, and `chunk-error`.

They are helpful in better styling using CSS.

A good example is `html_document` whose template fills background of code blocks by gray if they have any class attributes and by white if they have no class attributes.
This is causing output chunk with `numberLines` class to be filled by gray which should be white.
To fix the output, users have to modify the `class.output` option to something like `c("numberLines", "chunk-output")` so that stylesheet can identify which code block is the output.

**NOTE:** I will aso make PR on `rmarkdown` to update `html_document`'s CSS reflecting this `PR`. Otherwise, background of code blocks with `chunk-output`, `chunk-message`, `chunk-warning`, and `chunk-error` are filled by gray which should be white.

## Example input and output in md

```{r error = TRUE}
"hello"
message("hello")
warning("hello")
stop("hello")
```

becomes

````
```{.r .chunk-source}
"hello"
```

```{.chunk-output}
## [1] "hello"
```

```{.r .chunk-source}
message("hello")
```

```{.chunk-message}
## hello
```

```{.r .chunk-source}
warning("hello")
```

```{.chunk-warning}
## Warning: hello
```

```{.r .chunk-source}
stop("hello")
```

```{.chunk-error}
## Error in eval(expr, envir, enclos): hello
```
````